### PR TITLE
Fix: SSRエラー「window is not defined」の修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,13 @@ import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import LayerControlPanel from '@/components/LayerControlPanel'
 import BusStopSidebar from '@/components/BusStopSidebar'
-import ReachabilityLayer from '@/components/ReachabilityLayer'
-import PopulationLayer from '@/components/PopulationLayer'
-import BusStopMarker from '@/components/BusStopMarker'
 import { BusStop, ReachabilityGeoJSON, PopulationGeoJSON } from '@/types'
 
-// Map コンポーネントは動的インポート (SSR無効化)
+// Leafletを使用するコンポーネントは動的インポート (SSR無効化)
 const Map = dynamic(() => import('@/components/Map'), { ssr: false })
+const ReachabilityLayer = dynamic(() => import('@/components/ReachabilityLayer'), { ssr: false })
+const PopulationLayer = dynamic(() => import('@/components/PopulationLayer'), { ssr: false })
+const BusStopMarker = dynamic(() => import('@/components/BusStopMarker'), { ssr: false })
 
 // ダミーデータ: 停留所候補
 const dummyBusStops: BusStop[] = [


### PR DESCRIPTION
## 問題
`window is not defined` のランタイムエラーが発生していました。

## 原因
react-leafletを使用する以下のコンポーネントがSSR時に評価され、`window`オブジェクトにアクセスしようとしていました：
- ReachabilityLayer
- PopulationLayer
- BusStopMarker

## 解決策
これらのコンポーネントを動的インポート（`dynamic(() => import(...), { ssr: false })`）に変更し、SSRを無効化しました。

## 変更内容
- `src/app/page.tsx`: 3つのコンポーネントを動的インポートに変更

## 動作確認
✅ エラーが解消され、正常に動作することを確認済み

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>