### PR TITLE
feat: API統合と施設タイプ別到達圏表示機能

### DIFF
--- a/src/components/LayerControlPanel.tsx
+++ b/src/components/LayerControlPanel.tsx
@@ -1,44 +1,67 @@
+import { FacilityType } from '@/types'
+
 interface LayerControlPanelProps {
-  showReachability1: boolean
-  showReachability2: boolean
+  showReachability1: Record<FacilityType, boolean>
+  showReachability2: Record<FacilityType, boolean>
   showPopulation: boolean
-  onToggleReachability1: () => void
-  onToggleReachability2: () => void
+  availableFacilities: FacilityType[]
+  onToggleReachability1: (facility: FacilityType) => void
+  onToggleReachability2: (facility: FacilityType) => void
   onTogglePopulation: () => void
+}
+
+const FACILITY_LABELS: Record<FacilityType, string> = {
+  hospital: '病院',
+  shopping: '商業施設',
 }
 
 export default function LayerControlPanel({
   showReachability1,
   showReachability2,
   showPopulation,
+  availableFacilities,
   onToggleReachability1,
   onToggleReachability2,
   onTogglePopulation,
 }: LayerControlPanelProps) {
   return (
     <div className="bg-white shadow-md px-6 py-4 border-b border-gray-200">
-      <div className="flex gap-6 items-center">
+      <div className="flex gap-8 items-center flex-wrap">
         <h2 className="font-semibold text-gray-700">レイヤー表示</h2>
 
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={showReachability1}
-            onChange={onToggleReachability1}
-            className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
-          />
-          <span className="text-sm text-gray-700">到達圏1（現状）</span>
-        </label>
+        {availableFacilities && availableFacilities.length > 0 && (
+          <>
+            <div className="flex gap-4 items-center">
+              <span className="text-sm text-gray-600">到達圏1（現状）:</span>
+              {availableFacilities.map((facility) => (
+                <label key={facility} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={showReachability1[facility]}
+                    onChange={() => onToggleReachability1(facility)}
+                    className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                  />
+                  <span className="text-sm text-gray-700">{FACILITY_LABELS[facility]}</span>
+                </label>
+              ))}
+            </div>
 
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={showReachability2}
-            onChange={onToggleReachability2}
-            className="w-4 h-4 text-green-600 rounded focus:ring-2 focus:ring-green-500"
-          />
-          <span className="text-sm text-gray-700">到達圏2（コミュニティバス後）</span>
-        </label>
+            <div className="flex gap-4 items-center">
+              <span className="text-sm text-gray-600">到達圏2（コミュニティバス後）:</span>
+              {availableFacilities.map((facility) => (
+                <label key={facility} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={showReachability2[facility]}
+                    onChange={() => onToggleReachability2(facility)}
+                    className="w-4 h-4 text-green-600 rounded focus:ring-2 focus:ring-green-500"
+                  />
+                  <span className="text-sm text-gray-700">{FACILITY_LABELS[facility]}</span>
+                </label>
+              ))}
+            </div>
+          </>
+        )}
 
         <label className="flex items-center gap-2 cursor-pointer">
           <input

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -1,0 +1,59 @@
+import { FacilityType } from '@/types'
+
+interface SearchPanelProps {
+  selectedFacilities: FacilityType[]
+  maxMinute: number
+  onToggleFacility: (facility: FacilityType) => void
+  onMaxMinuteChange: (value: number) => void
+}
+
+const FACILITY_LABELS: Record<FacilityType, string> = {
+  hospital: '病院',
+  shopping: '商業施設',
+}
+
+export default function SearchPanel({
+  selectedFacilities,
+  maxMinute,
+  onToggleFacility,
+  onMaxMinuteChange,
+}: SearchPanelProps) {
+  return (
+    <div className="bg-white shadow-md px-6 py-4 border-b border-gray-200">
+      <div className="flex gap-8 items-center">
+        <h2 className="font-semibold text-gray-700">検索条件</h2>
+
+        <div className="flex gap-4 items-center">
+          <span className="text-sm text-gray-600">施設タイプ:</span>
+          {(Object.keys(FACILITY_LABELS) as FacilityType[]).map((facility) => (
+            <label key={facility} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={selectedFacilities.includes(facility)}
+                onChange={() => onToggleFacility(facility)}
+                className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+              />
+              <span className="text-sm text-gray-700">{FACILITY_LABELS[facility]}</span>
+            </label>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="max-minute" className="text-sm text-gray-600">
+            最大到達時間:
+          </label>
+          <input
+            id="max-minute"
+            type="number"
+            value={maxMinute}
+            onChange={(e) => onMaxMinuteChange(Number(e.target.value))}
+            min="1"
+            max="120"
+            className="w-20 px-2 py-1 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <span className="text-sm text-gray-600">分</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -1,90 +1,194 @@
 import { useState, useCallback } from 'react'
-import { BusStop, ReachabilityGeoJSON, PopulationGeoJSON } from '@/types'
+import { BusStop, FacilityType, APIRequest, APIResponse, FacilityReachability } from '@/types'
+
+const API_URL = 'https://prometheus-h24i.onrender.com/search/area'
 
 export function useMapState() {
+  // --- 検索条件 ---
+  const [selectedFacilities, setSelectedFacilities] = useState<FacilityType[]>(['hospital', 'shopping'])
+  const [maxMinute, setMaxMinute] = useState(60)
+
   // --- レイヤー表示状態 ---
-  const [showReachability1, setShowReachability1] = useState(true)
-  const [showReachability2, setShowReachability2] = useState(false)
+  const [showReachability1, setShowReachability1] = useState<Record<FacilityType, boolean>>({
+    hospital: false,
+    shopping: false,
+  })
+  const [showReachability2, setShowReachability2] = useState<Record<FacilityType, boolean>>({
+    hospital: false,
+    shopping: false,
+  })
   const [showPopulation, setShowPopulation] = useState(false)
 
   // --- 停留所選択状態 ---
   const [selectedStops, setSelectedStops] = useState<BusStop[]>([])
-  const [reachability2Data, setReachability2Data] = useState<ReachabilityGeoJSON | null>(null)
-  const [populationData] = useState<PopulationGeoJSON | null>(null)
+
+  // --- データ ---
+  const [facilityData, setFacilityData] = useState<Record<FacilityType, FacilityReachability | null>>({
+    hospital: null,
+    shopping: null,
+  })
+
+  // --- 施設タイプ切り替え ---
+  const toggleFacility = useCallback((facility: FacilityType) => {
+    setSelectedFacilities(prev =>
+      prev.includes(facility)
+        ? prev.filter(f => f !== facility)
+        : [...prev, facility]
+    )
+  }, [])
 
   // --- 停留所選択/解除のハンドラー ---
   const handleSelectStop = useCallback((stop: BusStop) => {
     const isSelected = selectedStops.some((s) => s.id === stop.id)
 
     if (isSelected) {
-      // 選択解除
       setSelectedStops(selectedStops.filter((s) => s.id !== stop.id))
     } else {
-      // 選択追加
       setSelectedStops([...selectedStops, stop])
     }
   }, [selectedStops])
 
   // --- 進むボタンのハンドラー ---
   const handleProceed = useCallback(async () => {
-    if (selectedStops.length < 2) return
+    if (selectedStops.length < 2 || selectedFacilities.length === 0) return
 
-    // TODO: バックエンドAPIを呼び出して到達圏2を取得
-    console.log('選択された停留所:', selectedStops)
-
-    // ダミーデータで到達圏2を設定
-    const dummyReachability2: ReachabilityGeoJSON = {
-      type: 'FeatureCollection',
-      features: [
-        {
-          type: 'Feature',
-          geometry: {
-            type: 'Polygon',
-            coordinates: [
-              [
-                [139.763, 35.677],
-                [139.773, 35.677],
-                [139.773, 35.687],
-                [139.763, 35.687],
-                [139.763, 35.677],
-              ],
-            ],
-          },
-          properties: { name: 'コミュニティバス後の到達圏' },
+    try {
+      // リクエストボディの構築
+      const requestBody: APIRequest = {
+        'target-spots': selectedFacilities,
+        'max-minute': maxMinute,
+        combus: {
+          stops: selectedStops.map(stop => ({
+            lat: stop.lat,
+            lon: stop.lng,
+          })),
+          // 循環バス: 終点→始点も含めてstopsと同じ数
+          sections: Array(selectedStops.length).fill({ duration: 5 }),
         },
-      ],
-    }
+      }
 
-    setReachability2Data(dummyReachability2)
-    setShowReachability2(true)
-  }, [selectedStops])
+      console.log('API Request:', requestBody)
+
+      // TODO: バックエンド開発完了後、requestBodyを使用
+      const fixedRequestBody = {
+        'target-spots': ['hospital', 'shopping'],
+        'max-minute': 60,
+        combus: {
+          stops: [
+            { lat: 36.65742, lon: 137.17421 },
+            { lat: 36.68936, lon: 137.18519 },
+            { lat: 36.67738, lon: 137.23892 },
+            { lat: 36.65493, lon: 137.24001 },
+            { lat: 36.63964, lon: 137.21958 },
+          ],
+          sections: [
+            { duration: 6 },
+            { duration: 9 },
+            { duration: 5 },
+            { duration: 7 },
+            { duration: 12 },
+          ],
+        },
+      }
+
+      const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(fixedRequestBody), // 一時的に固定リクエスト
+      })
+
+      if (!response.ok) {
+        throw new Error(`API Error: ${response.status}`)
+      }
+
+      const data: APIResponse = await response.json()
+      console.log('API Response:', data)
+
+      if (data.status === 'OK') {
+        // レスポンスからデータを設定
+        const newFacilityData: Record<FacilityType, FacilityReachability | null> = {
+          hospital: data.result.hospital || null,
+          shopping: data.result.shopping || null,
+        }
+        setFacilityData(newFacilityData)
+
+        // 取得できた施設タイプのレイヤーを自動的に表示
+        const newShowReachability1 = { ...showReachability1 }
+        const newShowReachability2 = { ...showReachability2 }
+
+        selectedFacilities.forEach(facility => {
+          if (data.result[facility]) {
+            newShowReachability1[facility] = true
+            newShowReachability2[facility] = true
+          }
+        })
+
+        setShowReachability1(newShowReachability1)
+        setShowReachability2(newShowReachability2)
+      }
+    } catch (error) {
+      console.error('API Call Error:', error)
+      alert('APIの呼び出しに失敗しました')
+    }
+  }, [selectedStops, selectedFacilities, maxMinute, showReachability1, showReachability2])
 
   // --- 戻るボタンのハンドラー ---
   const handleReset = useCallback(() => {
     setSelectedStops([])
-    setReachability2Data(null)
-    setShowReachability2(false)
+    setFacilityData({
+      hospital: null,
+      shopping: null,
+    })
+    setShowReachability1({
+      hospital: false,
+      shopping: false,
+    })
+    setShowReachability2({
+      hospital: false,
+      shopping: false,
+    })
   }, [])
 
   // --- レイヤー表示切り替えハンドラー ---
-  const toggleReachability1 = useCallback(() => {
-    setShowReachability1(!showReachability1)
-  }, [showReachability1])
+  const toggleReachability1 = useCallback((facility: FacilityType) => {
+    setShowReachability1(prev => ({
+      ...prev,
+      [facility]: !prev[facility],
+    }))
+  }, [])
 
-  const toggleReachability2 = useCallback(() => {
-    setShowReachability2(!showReachability2)
-  }, [showReachability2])
+  const toggleReachability2 = useCallback((facility: FacilityType) => {
+    setShowReachability2(prev => ({
+      ...prev,
+      [facility]: !prev[facility],
+    }))
+  }, [])
 
   const togglePopulation = useCallback(() => {
     setShowPopulation(!showPopulation)
   }, [showPopulation])
 
+  // 利用可能な施設タイプ（データが取得できているもの）
+  const availableFacilities = selectedFacilities.filter(
+    facility => facilityData[facility] !== null
+  )
+
   return {
+    // 検索条件
+    search: {
+      selectedFacilities,
+      maxMinute,
+      toggleFacility,
+      setMaxMinute,
+    },
     // レイヤー関連
     layers: {
       showReachability1,
       showReachability2,
       showPopulation,
+      availableFacilities,
       toggleReachability1,
       toggleReachability2,
       togglePopulation,
@@ -92,15 +196,14 @@ export function useMapState() {
     // 停留所関連
     stops: {
       selected: selectedStops,
-      canProceed: selectedStops.length >= 2,
+      canProceed: selectedStops.length >= 2 && selectedFacilities.length > 0,
       onSelect: handleSelectStop,
       onProceed: handleProceed,
       onReset: handleReset,
     },
     // データ
     data: {
-      reachability2: reachability2Data,
-      population: populationData,
+      facilities: facilityData,
     },
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,3 +35,47 @@ export interface BusRouteResponse {
   route: ReachabilityGeoJSON
   reachability2: ReachabilityGeoJSON
 }
+
+// API関連の型定義
+export type FacilityType = 'hospital' | 'shopping'
+
+export interface APIRequest {
+  'target-spots': FacilityType[]
+  'max-minute': number
+  combus: {
+    stops: Array<{
+      lat: number
+      lon: number
+    }>
+    sections: Array<{
+      duration: number
+    }>
+  }
+}
+
+export interface MultiPolygon {
+  type: 'MultiPolygon'
+  coordinates: number[][][][]
+}
+
+export interface FacilitySpot {
+  lat: number
+  lon: number
+  name: string
+  type: FacilityType
+}
+
+export interface FacilityReachability {
+  reachable: {
+    original: MultiPolygon
+    'with-combus': MultiPolygon
+  }
+  spots: FacilitySpot[]
+}
+
+export interface APIResponse {
+  result: {
+    [key in FacilityType]?: FacilityReachability
+  }
+  status: string
+}


### PR DESCRIPTION
## 概要
実APIとの統合と施設タイプ別の到達圏表示機能を実装しました。

## 実装内容

### ✅ 新機能
- **施設タイプ選択**: 病院・商業施設を複数選択可能
- **最大到達時間入力**: 数値で指定（デフォルト60分）
- **API統合**: 実際のバックエンドAPIと連携
- **施設別レイヤー表示**: 施設タイプごとに到達圏1/2を表示/非表示切り替え

### 📦 新規コンポーネント
- `SearchPanel`: 検索条件入力UI（施設タイプ、最大到達時間）

### 🔄 更新コンポーネント
- `LayerControlPanel`: 施設タイプ別レイヤー切り替えに対応
- `useMapState`: API呼び出しと状態管理を拡張
- `page.tsx`: 新UIとAPI連携に対応

### 🔌 API統合
- **エンドポイント**: `https://prometheus-h24i.onrender.com/search/area`
- **リクエスト**: 施設タイプ、最大到達時間、停留所情報
- **レスポンス**: 施設タイプごとの到達圏（MultiPolygon）
- **データ変換**: MultiPolygon → GeoJSON FeatureCollection
- **エラーハンドリング**: try-catch + アラート表示

### 📊 データフロー
1. ユーザーが停留所を2箇所以上選択
2. 施設タイプ（病院/商業施設）を選択
3. 最大到達時間を設定
4. 「進む」ボタンでAPI呼び出し
5. 取得した到達圏を施設タイプごとに表示
6. レイヤーパネルで表示切り替え

### 🎨 UI変更
- 上部に検索条件パネルを追加
- レイヤーコントロールパネルを2段構成に
  - 到達圏1: 施設タイプごとにチェックボックス
  - 到達圏2: 施設タイプごとにチェックボックス

## ⚠️ 一時的な制約
バックエンド開発待ちのため、API呼び出し時は固定リクエストを送信しています。

**該当箇所**: `src/hooks/useMapState.ts:72-100`

バックエンド対応後、以下の修正が必要です：
```typescript
// 修正前
body: JSON.stringify(fixedRequestBody)

// 修正後
body: JSON.stringify(requestBody)
```

## 動作確認
- ✅ 施設タイプ選択
- ✅ 最大到達時間入力
- ✅ API呼び出し成功
- ✅ 到達圏表示
- ✅ レイヤー切り替え
- ✅ エラーハンドリング

## スクリーンショット
（動作確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>