### PR TITLE
feat: 選択された停留所間のルート可視化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "leaflet": "^1.9.4",
+        "leaflet-polylinedecorator": "^1.6.0",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -18,6 +19,7 @@
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/leaflet": "^1.9.20",
+        "@types/leaflet-polylinedecorator": "^1.6.5",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1319,6 +1321,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/leaflet-polylinedecorator": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-polylinedecorator/-/leaflet-polylinedecorator-1.6.5.tgz",
+      "integrity": "sha512-m3hMuCyii8t7N/t1xc9aMzpA/tTnc/WFq63yR334Fgbw4jDytTCUcTNvACmod6bnZl5oCigqyTd7Pbb+VQtGZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "^1.9"
       }
     },
     "node_modules/@types/node": {
@@ -4211,6 +4223,21 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet-polylinedecorator": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/leaflet-polylinedecorator/-/leaflet-polylinedecorator-1.6.0.tgz",
+      "integrity": "sha512-kn3krmZRetgvN0wjhgYL8kvyLS0tUogAl0vtHuXQnwlYNjbl7aLQpkoFUo8UB8gVZoB0dhI4Tb55VdTJAcYzzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "leaflet-rotatedmarker": "^0.2.0"
+      }
+    },
+    "node_modules/leaflet-rotatedmarker": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
+      "integrity": "sha512-yc97gxLXwbZa+Gk9VCcqI0CkvIBC9oNTTjFsHqq4EQvANrvaboib4UdeQLyTnEqDpaXHCqzwwVIDHtvz2mUiDg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "leaflet": "^1.9.4",
+    "leaflet-polylinedecorator": "^1.6.0",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -19,6 +20,7 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/leaflet": "^1.9.20",
+    "@types/leaflet-polylinedecorator": "^1.6.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ const Map = dynamic(() => import('@/components/Map'), { ssr: false })
 const ReachabilityLayer = dynamic(() => import('@/components/ReachabilityLayer'), { ssr: false })
 const PopulationLayer = dynamic(() => import('@/components/PopulationLayer'), { ssr: false })
 const BusStopMarker = dynamic(() => import('@/components/BusStopMarker'), { ssr: false })
+const BusRoutePolyline = dynamic(() => import('@/components/BusRoutePolyline'), { ssr: false })
 
 // ダミーデータ: 停留所候補
 const dummyBusStops: BusStop[] = [
@@ -111,6 +112,9 @@ export default function Home() {
 
             {/* 人口分布 */}
             {layers.showPopulation && <PopulationLayer data={null} />}
+
+            {/* バスルート */}
+            <BusRoutePolyline stops={stops.selected} />
 
             {/* 停留所マーカー */}
             {dummyBusStops.map((stop) => {

--- a/src/components/BusRoutePolyline.tsx
+++ b/src/components/BusRoutePolyline.tsx
@@ -1,0 +1,159 @@
+import { Polyline, Marker } from 'react-leaflet'
+import L from 'leaflet'
+import { BusStop } from '@/types'
+
+interface BusRoutePolylineProps {
+  stops: BusStop[]
+}
+
+// 矢印アイコンを作成（SVGで上向き三角形を使用）
+const createArrowIcon = (rotation: number) => {
+  return L.divIcon({
+    className: 'arrow-icon',
+    html: `
+      <svg width="20" height="20" viewBox="0 0 20 20" style="transform: rotate(${rotation}deg);">
+        <path d="M10 2 L18 18 L10 14 L2 18 Z" fill="#2563eb" stroke="#2563eb" stroke-width="1"/>
+      </svg>
+    `,
+    iconSize: [20, 20],
+    iconAnchor: [10, 10],
+  })
+}
+
+// 2点間の角度を計算（SVG三角形が上向きを基準として）
+const calculateAngle = (from: [number, number], to: [number, number]): number => {
+  const [lat1, lng1] = from
+  const [lat2, lng2] = to
+
+  // 経度(x)と緯度(y)の差分
+  const dx = lng2 - lng1  // 経度: 東西方向
+  const dy = lat2 - lat1  // 緯度: 南北方向
+
+  // atan2(dx, dy)で角度を計算（上向きを0度とするため、引数の順序を逆に）
+  // 北: 0度、東: 90度、南: 180度/-180度、西: -90度
+  const angle = Math.atan2(dx, dy) * (180 / Math.PI)
+
+  return angle
+}
+
+// 2点間の指定位置の点を計算（ratio: 0.0-1.0）
+const getPointOnLine = (from: [number, number], to: [number, number], ratio: number): [number, number] => {
+  const [lat1, lng1] = from
+  const [lat2, lng2] = to
+  return [
+    lat1 + (lat2 - lat1) * ratio,
+    lng1 + (lng2 - lng1) * ratio,
+  ]
+}
+
+// 線を垂直方向にオフセットした点を計算
+const getOffsetPoint = (point: [number, number], angle: number, offsetPixels: number): [number, number] => {
+  // 1ピクセル ≈ 0.00001度と仮定（緯度による）
+  const offsetDegrees = offsetPixels * 0.00001
+
+  // 線に垂直な方向（+90度）にオフセット
+  const offsetAngle = (angle + 90) * (Math.PI / 180)
+
+  return [
+    point[0] + Math.sin(offsetAngle) * offsetDegrees,
+    point[1] + Math.cos(offsetAngle) * offsetDegrees,
+  ]
+}
+
+export default function BusRoutePolyline({ stops }: BusRoutePolylineProps) {
+  if (stops.length < 2) return null
+
+  const isTwoStopRoute = stops.length === 2
+
+  if (isTwoStopRoute) {
+    // 2停留所の場合: 往路と復路を物理的にずらして描画
+    const stop1 = [stops[0].lat, stops[0].lng] as [number, number]
+    const stop2 = [stops[1].lat, stops[1].lng] as [number, number]
+
+    const outboundAngle = calculateAngle(stop1, stop2)
+    const returnAngle = calculateAngle(stop2, stop1)
+
+    // 往路: 線を左にオフセット
+    const outboundStop1 = getOffsetPoint(stop1, outboundAngle, -50)
+    const outboundStop2 = getOffsetPoint(stop2, outboundAngle, -50)
+    const outboundArrowPos = getPointOnLine(outboundStop1, outboundStop2, 0.5)
+
+    // 復路: 線を右にオフセット
+    const returnStop1 = getOffsetPoint(stop2, returnAngle, -50)
+    const returnStop2 = getOffsetPoint(stop1, returnAngle, -50)
+    const returnArrowPos = getPointOnLine(returnStop1, returnStop2, 0.5)
+
+    return (
+      <>
+        {/* 往路 */}
+        <Polyline
+          positions={[outboundStop1, outboundStop2]}
+          pathOptions={{
+            color: '#2563eb',
+            weight: 3,
+            opacity: 0.7,
+          }}
+        />
+        <Marker
+          position={outboundArrowPos}
+          icon={createArrowIcon(outboundAngle)}
+          interactive={false}
+        />
+
+        {/* 復路 */}
+        <Polyline
+          positions={[returnStop1, returnStop2]}
+          pathOptions={{
+            color: '#2563eb',
+            weight: 3,
+            opacity: 0.7,
+          }}
+        />
+        <Marker
+          position={returnArrowPos}
+          icon={createArrowIcon(returnAngle)}
+          interactive={false}
+        />
+      </>
+    )
+  }
+
+  // 3つ以上の停留所の場合: 通常の循環ルート
+  const positions = stops.map((stop) => [stop.lat, stop.lng] as [number, number])
+  positions.push([stops[0].lat, stops[0].lng])
+
+  const arrows = []
+  for (let i = 0; i < positions.length - 1; i++) {
+    const from = positions[i]
+    const to = positions[i + 1]
+    const arrowPosition = getPointOnLine(from, to, 0.5)
+    const angle = calculateAngle(from, to)
+
+    arrows.push({
+      position: arrowPosition,
+      angle: angle,
+      key: `arrow-${i}`,
+    })
+  }
+
+  return (
+    <>
+      <Polyline
+        positions={positions}
+        pathOptions={{
+          color: '#2563eb',
+          weight: 3,
+          opacity: 0.7,
+        }}
+      />
+      {arrows.map((arrow) => (
+        <Marker
+          key={arrow.key}
+          position={arrow.position}
+          icon={createArrowIcon(arrow.angle)}
+          interactive={false}
+        />
+      ))}
+    </>
+  )
+}


### PR DESCRIPTION
## 概要

選択された停留所間を線で接続し、進行方向を矢印で示す機能を実装しました。

## 実装内容

### 新規コンポーネント
- **BusRoutePolyline.tsx**: バスルート表示コンポーネント
  - 選択された停留所間を青い線で接続
  - 各区間の中点にSVG三角形の矢印を配置し、進行方向を明示
  - 循環ルート対応（最後の停留所から最初の停留所へ戻る）

### 特殊対応
- **2停留所の場合**: 往路と復路の矢印が重ならないよう、線を垂直方向に物理的にオフセット
  - 往路: 線の左側50ピクセル分オフセット
  - 復路: 線の右側50ピクセル分オフセット
- **3停留所以上の場合**: 通常の循環ルートとして1本の線で表示

### 矢印の実装
- SVG三角形を使用（上向きを基準）
- 角度計算: `atan2(dx, dy)`で北を0度とする
- 各区間の進行方向に合わせて矢印を回転

## 変更ファイル
- `src/components/BusRoutePolyline.tsx` (新規)
- `src/app/page.tsx` (動的インポート追加)
- `package.json` (依存関係追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)