### PR TITLE
feat: 選択された停留所マーカーの数字表示を改善

### DIFF
--- a/src/components/BusStopMarker.tsx
+++ b/src/components/BusStopMarker.tsx
@@ -14,10 +14,51 @@ interface BusStopMarkerProps {
 // カスタムアイコンの作成
 const createIcon = (isSelected: boolean, order?: number) => {
   const color = isSelected ? '#2563eb' : '#94a3b8'
+
+  if (isSelected && order !== undefined) {
+    // 選択済み: 数字をピンの上側に大きく表示
+    const badgeHtml = `
+      <div style="position: relative; width: 32px; height: 64px;">
+        <div style="
+          background: ${color};
+          border: 3px solid white;
+          border-radius: 50%;
+          width: 32px;
+          height: 32px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+          position: absolute;
+          left: 0;
+          top: 0;
+        ">
+          <span style="
+            color: white;
+            font-size: 18px;
+            font-weight: bold;
+            line-height: 1;
+          ">${order}</span>
+        </div>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="${color}" width="32" height="32" style="position: absolute; bottom: 0; left: 0;">
+          <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+        </svg>
+      </div>
+    `
+
+    return L.divIcon({
+      html: badgeHtml,
+      className: 'custom-marker-with-badge',
+      iconSize: [32, 64],
+      iconAnchor: [16, 64],
+      popupAnchor: [0, -64],
+    })
+  }
+
+  // 未選択: 通常のピン
   const svgIcon = `
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="${color}" width="32" height="32">
       <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-      ${isSelected && order !== undefined ? `<text x="12" y="10" text-anchor="middle" font-size="8" fill="white" font-weight="bold">${order}</text>` : ''}
     </svg>
   `
 


### PR DESCRIPTION
## 概要

選択された停留所マーカーの数字表示を大きく見やすく改善しました。

## 実装内容

### マーカーデザインの変更
- **選択済みマーカー**: 
  - 数字をピンの上側に配置（縦並び）
  - 円形バッジサイズ: 32px × 32px
  - 数字フォントサイズ: 18px（太字）
  - 白い縁取り（3px）とシャドウで視認性向上
  - ピンとバッジが重ならず、数字が明確に見える

- **未選択マーカー**: 
  - 従来通りのグレーのピン表示

### ビジュアル改善
- バッジとピンを分離して配置することで、数字が埋もれない
- 全体の高さ: 64px（バッジ32px + ピン32px）
- アイコンアンカー位置を調整し、正確な位置表示を維持

## 変更ファイル
- `src/components/BusStopMarker.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)