### PR TITLE
feat: 停留所リストのドラッグ&ドロップ順序変更機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "shikan",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "leaflet": "^1.9.4",
         "leaflet-polylinedecorator": "^1.6.0",
         "next": "15.5.4",
@@ -40,6 +43,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "leaflet": "^1.9.4",
     "leaflet-polylinedecorator": "^1.6.0",
     "next": "15.5.4",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,6 +75,7 @@ export default function Home() {
           onProceed={stops.onProceed}
           onReset={stops.onReset}
           canProceed={stops.canProceed}
+          onReorder={stops.onReorder}
         />
 
         {/* 地図エリア */}

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -151,6 +151,11 @@ export function useMapState() {
     })
   }, [])
 
+  // --- 停留所順序変更ハンドラー ---
+  const handleReorderStops = useCallback((newStops: BusStop[]) => {
+    setSelectedStops(newStops)
+  }, [])
+
   // --- レイヤー表示切り替えハンドラー ---
   const toggleReachability1 = useCallback((facility: FacilityType) => {
     setShowReachability1(prev => ({
@@ -200,6 +205,7 @@ export function useMapState() {
       onSelect: handleSelectStop,
       onProceed: handleProceed,
       onReset: handleReset,
+      onReorder: handleReorderStops,
     },
     // データ
     data: {


### PR DESCRIPTION
## 概要

選択された停留所リストをドラッグ&ドロップで順序変更できる機能を実装しました。

Closes #8

## 実装内容

### ライブラリ
- **@dnd-kit/core**: モダンなドラッグ&ドロップライブラリ（React 18対応）
- **@dnd-kit/sortable**: ソート機能用の拡張
- **@dnd-kit/utilities**: ユーティリティ関数

### 主な変更

**BusStopSidebar.tsx**
- `DndContext`と`SortableContext`を使用してドラッグ&ドロップ機能を実装
- `SortableStopItem`コンポーネントを作成
- ドラッグハンドル: 右側の⋮⋮アイコンのみでドラッグ可能
- 移動制限: 縦方向のみに制限（横方向への移動を無効化）
- ドラッグ中は半透明表示

**useMapState.ts**
- `handleReorderStops`ハンドラーを追加
- 順序変更を`selectedStops`ステートに反映

**page.tsx**
- `onReorder`プロップを`BusStopSidebar`に渡す

### UX改善
- ⋮⋮アイコンにホバー時に色が変わる
- ドラッグ可能であることが視覚的に明確
- 順序変更が即座にマーカー番号とルート表示に反映

## 動作確認
- [x] ⋮⋮アイコンをドラッグして順序変更が可能
- [x] 縦方向のみに移動
- [x] マーカーの数字が順序に応じて更新
- [x] ルート表示が順序に応じて更新
- [x] ESLintエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)