### PR TITLE
feat: 進むボタン押下後の編集ロック機能を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,6 +76,7 @@ export default function Home() {
           onReset={stops.onReset}
           canProceed={stops.canProceed}
           onReorder={stops.onReorder}
+          isEditable={stops.isEditable}
         />
 
         {/* 地図エリア */}
@@ -128,7 +129,7 @@ export default function Home() {
                   stop={stop}
                   isSelected={isSelected}
                   selectionOrder={isSelected ? selectedIndex + 1 : undefined}
-                  onSelect={stops.onSelect}
+                  onSelect={stops.isEditable ? stops.onSelect : () => {}}
                 />
               )
             })}

--- a/src/components/BusStopSidebar.tsx
+++ b/src/components/BusStopSidebar.tsx
@@ -24,10 +24,11 @@ interface BusStopSidebarProps {
   onReset: () => void
   canProceed: boolean
   onReorder: (newStops: BusStop[]) => void
+  isEditable: boolean
 }
 
 // ドラッグ可能な停留所アイテムコンポーネント
-function SortableStopItem({ stop, index }: { stop: BusStop; index: number }) {
+function SortableStopItem({ stop, index, isEditable }: { stop: BusStop; index: number; isEditable: boolean }) {
   const {
     attributes,
     listeners,
@@ -35,7 +36,7 @@ function SortableStopItem({ stop, index }: { stop: BusStop; index: number }) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: stop.id })
+  } = useSortable({ id: stop.id, disabled: !isEditable })
 
   // 縦方向のみの移動に制限
   const style = {
@@ -50,19 +51,23 @@ function SortableStopItem({ stop, index }: { stop: BusStop; index: number }) {
     <li
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-3 p-3 bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 transition-colors"
+      className={`flex items-center gap-3 p-3 bg-blue-50 rounded-lg border border-blue-200 transition-colors min-h-[60px] ${
+        isEditable ? 'hover:bg-blue-100' : 'opacity-75'
+      }`}
     >
       <span className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">
         {index + 1}
       </span>
       <span className="text-sm text-gray-800">{stop.name}</span>
-      <span
-        {...attributes}
-        {...listeners}
-        className="ml-auto text-gray-400 text-lg cursor-move hover:text-gray-600 px-2"
-      >
-        ⋮⋮
-      </span>
+      {isEditable && (
+        <span
+          {...attributes}
+          {...listeners}
+          className="ml-auto text-gray-400 text-lg cursor-move hover:text-gray-600 px-2"
+        >
+          ⋮⋮
+        </span>
+      )}
     </li>
   )
 }
@@ -73,6 +78,7 @@ export default function BusStopSidebar({
   onReset,
   canProceed,
   onReorder,
+  isEditable,
 }: BusStopSidebarProps) {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -118,7 +124,7 @@ export default function BusStopSidebar({
             >
               <ol className="space-y-2">
                 {selectedStops.map((stop, index) => (
-                  <SortableStopItem key={stop.id} stop={stop} index={index} />
+                  <SortableStopItem key={stop.id} stop={stop} index={index} isEditable={isEditable} />
                 ))}
               </ol>
             </SortableContext>

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -22,6 +22,9 @@ export function useMapState() {
   // --- 停留所選択状態 ---
   const [selectedStops, setSelectedStops] = useState<BusStop[]>([])
 
+  // --- 編集ロック状態 ---
+  const [isEditable, setIsEditable] = useState(true)
+
   // --- データ ---
   const [facilityData, setFacilityData] = useState<Record<FacilityType, FacilityReachability | null>>({
     hospital: null,
@@ -127,6 +130,9 @@ export function useMapState() {
 
         setShowReachability1(newShowReachability1)
         setShowReachability2(newShowReachability2)
+
+        // 編集を無効化
+        setIsEditable(false)
       }
     } catch (error) {
       console.error('API Call Error:', error)
@@ -136,7 +142,7 @@ export function useMapState() {
 
   // --- 戻るボタンのハンドラー ---
   const handleReset = useCallback(() => {
-    setSelectedStops([])
+    // 停留所リストはリセットしない
     setFacilityData({
       hospital: null,
       shopping: null,
@@ -149,6 +155,8 @@ export function useMapState() {
       hospital: false,
       shopping: false,
     })
+    // 編集を再度可能にする
+    setIsEditable(true)
   }, [])
 
   // --- 停留所順序変更ハンドラー ---
@@ -202,6 +210,7 @@ export function useMapState() {
     stops: {
       selected: selectedStops,
       canProceed: selectedStops.length >= 2 && selectedFacilities.length > 0,
+      isEditable,
       onSelect: handleSelectStop,
       onProceed: handleProceed,
       onReset: handleReset,


### PR DESCRIPTION
## 概要

進むボタン押下後は停留所の編集を無効化し、戻るボタンで再編集可能にする機能を実装しました。

Closes #13

## 実装内容

### 状態管理
- **useMapState.ts**
  - `isEditable`ステートを追加（初期値: true）
  - 進むボタン押下後、API呼び出し成功時に`isEditable`をfalseに設定
  - 戻るボタン押下時に`isEditable`をtrueに戻す
  - 戻るボタンでは停留所リストをリセットしない（データとレイヤー表示のみリセット）

### UI制御
- **page.tsx**
  - マーカークリック時に`isEditable`をチェック
  - 編集不可時は空の関数を渡してクリックを無効化

- **BusStopSidebar.tsx**
  - `isEditable`プロップを追加
  - `SortableStopItem`に`isEditable`を渡し、ドラッグ&ドロップを制御
  - 編集不可時：
    - `useSortable`の`disabled`オプションでドラッグ無効化
    - ⋮⋮アイコンを非表示
    - 停留所リストを半透明表示（`opacity-75`）
  - 停留所リストアイテムの高さを固定（`min-h-[60px]`）

## UX改善
- 編集不可状態が視覚的に明確（半透明表示）
- ドラッグハンドル非表示で編集不可を直感的に理解できる
- 停留所リストの高さが一定で、UIが安定
- 戻るボタンで停留所選択を保持し、再編集が容易

## 動作確認
- [x] 進むボタン押下後、マーカークリックが無効化
- [x] 進むボタン押下後、ドラッグ&ドロップが無効化
- [x] 戻るボタン押下で再度編集可能
- [x] 戻るボタン押下後も停留所リストは保持
- [x] 停留所リストの高さが一定

🤖 Generated with [Claude Code](https://claude.com/claude-code)