### PR TITLE
feat: API実行中のローディング表示機能を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import SearchPanel from '@/components/SearchPanel'
 import LayerControlPanel from '@/components/LayerControlPanel'
 import BusStopSidebar from '@/components/BusStopSidebar'
+import Loading from '@/components/Loading'
 import { useMapState } from '@/hooks/useMapState'
 import { BusStop, FacilityType } from '@/types'
 
@@ -44,10 +45,12 @@ function multiPolygonToGeoJSON(multiPolygon: {
 }
 
 export default function Home() {
-  const { search, layers, stops, data } = useMapState()
+  const { search, layers, stops, data, ui } = useMapState()
 
   return (
     <div className="h-screen flex flex-col">
+      {/* ローディングオーバーレイ */}
+      {ui.isLoading && <Loading />}
       {/* 上部: 検索条件パネル */}
       <SearchPanel
         selectedFacilities={search.selectedFacilities}

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export default function Loading() {
+  const [dots, setDots] = useState('.')
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDots(prev => {
+        if (prev === '.') return '..'
+        if (prev === '..') return '...'
+        return '.'
+      })
+    }, 500) // 0.5秒ごとに変化
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-8 flex flex-col items-center shadow-xl">
+        <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-blue-600"></div>
+        <p className="mt-4 text-gray-700 font-medium">
+          読み込み中
+          <span className="inline-block w-6 text-left">{dots}</span>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -25,6 +25,9 @@ export function useMapState() {
   // --- 編集ロック状態 ---
   const [isEditable, setIsEditable] = useState(true)
 
+  // --- ローディング状態 ---
+  const [isLoading, setIsLoading] = useState(false)
+
   // --- データ ---
   const [facilityData, setFacilityData] = useState<Record<FacilityType, FacilityReachability | null>>({
     hospital: null,
@@ -54,6 +57,8 @@ export function useMapState() {
   // --- 進むボタンのハンドラー ---
   const handleProceed = useCallback(async () => {
     if (selectedStops.length < 2 || selectedFacilities.length === 0) return
+
+    setIsLoading(true)
 
     try {
       // リクエストボディの構築
@@ -137,6 +142,8 @@ export function useMapState() {
     } catch (error) {
       console.error('API Call Error:', error)
       alert('APIの呼び出しに失敗しました')
+    } finally {
+      setIsLoading(false)
     }
   }, [selectedStops, selectedFacilities, maxMinute, showReachability1, showReachability2])
 
@@ -219,6 +226,10 @@ export function useMapState() {
     // データ
     data: {
       facilities: facilityData,
+    },
+    // UI状態
+    ui: {
+      isLoading,
     },
   }
 }


### PR DESCRIPTION
## 概要

バックエンドAPI実行中にローディング表示を出す機能を実装しました。

Closes #15

## 実装内容

### Loadingコンポーネント
- **オーバーレイ**: 画面全体を覆う半透明の背景（`bg-black/30`）
- **スピナー**: 中央に配置、回転アニメーション（Tailwind `animate-spin`）
- **テキストアニメーション**: 「読み込み中...」のドットが0.5秒ごとに変化（. → .. → ... → .）
- **固定幅**: ドット部分を`w-6`で固定してガタつき防止

### 状態管理
- **useMapState.ts**
  - `isLoading`ステートを追加
  - API呼び出し開始時に`setIsLoading(true)`
  - `finally`句で確実に`setIsLoading(false)`を実行（エラー時も確実に終了）

### UI統合
- **page.tsx**
  - `ui.isLoading`を取得
  - ローディング中は`<Loading />`コンポーネントを表示

## UX
- API実行中は画面全体にオーバーレイが表示され、全ての操作を無効化
- 半透明なので後ろのコンテンツが見える
- スピナーとドットアニメーションで待機中であることが明確
- エラー時も確実にローディングが終了

## 動作確認
- [x] 進むボタン押下でローディング表示
- [x] オーバーレイで全操作が無効化
- [x] 半透明で後ろが見える
- [x] ドットアニメーションが動作
- [x] API完了後にローディングが消える
- [x] エラー時もローディングが消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)