### PR TITLE
feat: スポット一覧をバックエンドAPIから取得し、種別ごとに表示

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,24 @@
 import MapView from '@/components/MapView'
 import { fetchBusStops } from '@/lib/busStops'
+import { fetchSpots } from '@/lib/spots'
+import { SPOT_LABELS } from '@/lib/spotLabels'
 
 export default async function Home() {
   const busStops = await fetchBusStops()
+  const { spots, types: spotTypes } = await fetchSpots()
 
-  return <MapView busStops={busStops} />
+  // スポットラベルマップを作成
+  const spotLabels = spotTypes.reduce((acc, type) => {
+    acc[type] = SPOT_LABELS[type] || type
+    return acc
+  }, {} as Record<string, string>)
+
+  return (
+    <MapView
+      busStops={busStops}
+      spots={spots}
+      spotTypes={spotTypes}
+      spotLabels={spotLabels}
+    />
+  )
 }

--- a/src/components/LayerControlPanel.tsx
+++ b/src/components/LayerControlPanel.tsx
@@ -1,18 +1,14 @@
 import { FacilityType } from '@/types'
 
 interface LayerControlPanelProps {
-  showReachability1: Record<FacilityType, boolean>
-  showReachability2: Record<FacilityType, boolean>
+  showReachability1: Record<string, boolean>
+  showReachability2: Record<string, boolean>
   showPopulation: boolean
   availableFacilities: FacilityType[]
   onToggleReachability1: (facility: FacilityType) => void
   onToggleReachability2: (facility: FacilityType) => void
   onTogglePopulation: () => void
-}
-
-const FACILITY_LABELS: Record<FacilityType, string> = {
-  hospital: '病院',
-  shopping: '商業施設',
+  spotLabels: Record<string, string>
 }
 
 export default function LayerControlPanel({
@@ -23,6 +19,7 @@ export default function LayerControlPanel({
   onToggleReachability1,
   onToggleReachability2,
   onTogglePopulation,
+  spotLabels,
 }: LayerControlPanelProps) {
   return (
     <div className="bg-white shadow-md px-6 py-4 border-b border-gray-200">
@@ -41,7 +38,7 @@ export default function LayerControlPanel({
                     onChange={() => onToggleReachability1(facility)}
                     className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
                   />
-                  <span className="text-sm text-gray-700">{FACILITY_LABELS[facility]}</span>
+                  <span className="text-sm text-gray-700">{spotLabels[facility] || facility}</span>
                 </label>
               ))}
             </div>
@@ -56,7 +53,7 @@ export default function LayerControlPanel({
                     onChange={() => onToggleReachability2(facility)}
                     className="w-4 h-4 text-green-600 rounded focus:ring-2 focus:ring-green-500"
                   />
-                  <span className="text-sm text-gray-700">{FACILITY_LABELS[facility]}</span>
+                  <span className="text-sm text-gray-700">{spotLabels[facility] || facility}</span>
                 </label>
               ))}
             </div>

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -5,11 +5,10 @@ interface SearchPanelProps {
   maxMinute: number
   onToggleFacility: (facility: FacilityType) => void
   onMaxMinuteChange: (value: number) => void
-}
-
-const FACILITY_LABELS: Record<FacilityType, string> = {
-  hospital: '病院',
-  shopping: '商業施設',
+  availableSpotTypes: string[]
+  spotLabels: Record<string, string>
+  selectedSpotTypes: string[]
+  onToggleSpotType: (type: string) => void
 }
 
 export default function SearchPanel({
@@ -17,41 +16,62 @@ export default function SearchPanel({
   maxMinute,
   onToggleFacility,
   onMaxMinuteChange,
+  availableSpotTypes,
+  spotLabels,
+  selectedSpotTypes,
+  onToggleSpotType,
 }: SearchPanelProps) {
   return (
     <div className="bg-white shadow-md px-6 py-4 border-b border-gray-200">
-      <div className="flex gap-8 items-center">
-        <h2 className="font-semibold text-gray-700">検索条件</h2>
+      <div className="flex flex-col gap-4">
+        <div className="flex gap-8 items-center">
+          <h2 className="font-semibold text-gray-700">検索条件</h2>
 
-        <div className="flex gap-4 items-center">
-          <span className="text-sm text-gray-600">施設タイプ:</span>
-          {(Object.keys(FACILITY_LABELS) as FacilityType[]).map((facility) => (
-            <label key={facility} className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={selectedFacilities.includes(facility)}
-                onChange={() => onToggleFacility(facility)}
-                className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
-              />
-              <span className="text-sm text-gray-700">{FACILITY_LABELS[facility]}</span>
+          {availableSpotTypes && availableSpotTypes.length > 0 && (
+            <div className="flex gap-4 items-center">
+              <span className="text-sm text-gray-600">施設タイプ:</span>
+              {availableSpotTypes.map((type) => {
+                // スポット表示の状態を優先（マーカー表示制御）
+                const isChecked = selectedSpotTypes?.includes(type) ?? false
+
+                const handleToggle = () => {
+                  // 両方の状態を同期して切り替え
+                  onToggleFacility(type as FacilityType)
+                  onToggleSpotType(type)
+                }
+
+                return (
+                  <label key={type} className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={isChecked}
+                      onChange={handleToggle}
+                      className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                    />
+                    <span className="text-sm text-gray-700">
+                      {spotLabels?.[type] || type}
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <label htmlFor="max-minute" className="text-sm text-gray-600">
+              最大到達時間:
             </label>
-          ))}
-        </div>
-
-        <div className="flex items-center gap-2">
-          <label htmlFor="max-minute" className="text-sm text-gray-600">
-            最大到達時間:
-          </label>
-          <input
-            id="max-minute"
-            type="number"
-            value={maxMinute}
-            onChange={(e) => onMaxMinuteChange(Number(e.target.value))}
-            min="1"
-            max="120"
-            className="w-20 px-2 py-1 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          />
-          <span className="text-sm text-gray-600">分</span>
+            <input
+              id="max-minute"
+              type="number"
+              value={maxMinute}
+              onChange={(e) => onMaxMinuteChange(Number(e.target.value))}
+              min="1"
+              max="120"
+              className="w-20 px-2 py-1 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            <span className="text-sm text-gray-600">分</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/SpotMarker.tsx
+++ b/src/components/SpotMarker.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Marker, Popup } from 'react-leaflet'
+import L from 'leaflet'
+import { Spot } from '@/types'
+import { getSpotLabel } from '@/lib/spotLabels'
+
+interface SpotMarkerProps {
+  spot: Spot
+}
+
+// スポットタイプごとの色定義
+const SPOT_COLORS: Record<string, string> = {
+  hospital: '#ef4444', // 赤
+  shopping: '#3b82f6', // 青
+  'public-facility': '#10b981', // 緑
+}
+
+// デフォルト色
+const DEFAULT_COLOR = '#6b7280' // グレー
+
+// タイプごとのアイコンを作成
+const createSpotIcon = (type: string) => {
+  const color = SPOT_COLORS[type] || DEFAULT_COLOR
+
+  // 停留所マーカーと区別するため、四角形のアイコンを使用
+  const svgIcon = `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="${color}" width="24" height="24">
+      <rect x="3" y="3" width="18" height="18" rx="3" fill="${color}" stroke="white" stroke-width="2"/>
+      <circle cx="12" cy="12" r="4" fill="white"/>
+    </svg>
+  `
+
+  return L.divIcon({
+    html: svgIcon,
+    className: 'spot-marker',
+    iconSize: [24, 24],
+    iconAnchor: [12, 12],
+    popupAnchor: [0, -12],
+  })
+}
+
+export default function SpotMarker({ spot }: SpotMarkerProps) {
+  return (
+    <Marker position={[spot.lat, spot.lng]} icon={createSpotIcon(spot.type)}>
+      <Popup>
+        <div className="text-sm">
+          <p className="font-semibold">{spot.name}</p>
+          <p className="text-xs text-gray-600 mt-1">
+            種別: {getSpotLabel(spot.type)}
+          </p>
+        </div>
+      </Popup>
+    </Marker>
+  )
+}

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -1,22 +1,25 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { BusStop, FacilityType, APIRequest, APIResponse, FacilityReachability } from '@/types'
 
 const API_URL = 'https://prometheus-h24i.onrender.com/search/area'
 
-export function useMapState() {
+export function useMapState(availableSpotTypes: string[] = []) {
   // --- 検索条件 ---
-  const [selectedFacilities, setSelectedFacilities] = useState<FacilityType[]>(['hospital', 'shopping'])
+  const [selectedFacilities, setSelectedFacilities] = useState<FacilityType[]>([])
   const [maxMinute, setMaxMinute] = useState(60)
 
+  // --- スポット表示状態 ---
+  const [selectedSpotTypes, setSelectedSpotTypes] = useState<string[]>([])
+
+  // availableSpotTypesが変わったら両方を初期化（同期）
+  useEffect(() => {
+    setSelectedFacilities(availableSpotTypes)
+    setSelectedSpotTypes(availableSpotTypes)
+  }, [availableSpotTypes.join(',')]) // eslint-disable-line react-hooks/exhaustive-deps
+
   // --- レイヤー表示状態 ---
-  const [showReachability1, setShowReachability1] = useState<Record<FacilityType, boolean>>({
-    hospital: false,
-    shopping: false,
-  })
-  const [showReachability2, setShowReachability2] = useState<Record<FacilityType, boolean>>({
-    hospital: false,
-    shopping: false,
-  })
+  const [showReachability1, setShowReachability1] = useState<Record<string, boolean>>({})
+  const [showReachability2, setShowReachability2] = useState<Record<string, boolean>>({})
   const [showPopulation, setShowPopulation] = useState(false)
 
   // --- 停留所選択状態 ---
@@ -29,10 +32,7 @@ export function useMapState() {
   const [isLoading, setIsLoading] = useState(false)
 
   // --- データ ---
-  const [facilityData, setFacilityData] = useState<Record<FacilityType, FacilityReachability | null>>({
-    hospital: null,
-    shopping: null,
-  })
+  const [facilityData, setFacilityData] = useState<Record<string, FacilityReachability | null>>({})
 
   // --- 施設タイプ切り替え ---
   const toggleFacility = useCallback((facility: FacilityType) => {
@@ -75,8 +75,6 @@ export function useMapState() {
         },
       }
 
-      console.log('API Request:', requestBody)
-
       // TODO: バックエンド開発完了後、requestBodyを使用
       const fixedRequestBody = {
         'target-spots': ['hospital', 'shopping'],
@@ -112,7 +110,6 @@ export function useMapState() {
       }
 
       const data: APIResponse = await response.json()
-      console.log('API Response:', data)
 
       if (data.status === 'OK') {
         // レスポンスからデータを設定
@@ -150,18 +147,9 @@ export function useMapState() {
   // --- 戻るボタンのハンドラー ---
   const handleReset = useCallback(() => {
     // 停留所リストはリセットしない
-    setFacilityData({
-      hospital: null,
-      shopping: null,
-    })
-    setShowReachability1({
-      hospital: false,
-      shopping: false,
-    })
-    setShowReachability2({
-      hospital: false,
-      shopping: false,
-    })
+    setFacilityData({})
+    setShowReachability1({})
+    setShowReachability2({})
     // 編集を再度可能にする
     setIsEditable(true)
   }, [])
@@ -190,9 +178,18 @@ export function useMapState() {
     setShowPopulation(!showPopulation)
   }, [showPopulation])
 
+  // --- スポットタイプ切り替えハンドラー ---
+  const toggleSpotType = useCallback((type: string) => {
+    setSelectedSpotTypes(prev =>
+      prev.includes(type)
+        ? prev.filter(t => t !== type)
+        : [...prev, type]
+    )
+  }, [])
+
   // 利用可能な施設タイプ（データが取得できているもの）
   const availableFacilities = selectedFacilities.filter(
-    facility => facilityData[facility] !== null
+    facility => facilityData[facility]
   )
 
   return {
@@ -202,6 +199,11 @@ export function useMapState() {
       maxMinute,
       toggleFacility,
       setMaxMinute,
+    },
+    // スポット表示
+    spotDisplay: {
+      selectedTypes: selectedSpotTypes,
+      toggleType: toggleSpotType,
     },
     // レイヤー関連
     layers: {

--- a/src/lib/spotLabels.ts
+++ b/src/lib/spotLabels.ts
@@ -1,0 +1,12 @@
+// スポットタイプの日本語ラベル
+export const SPOT_LABELS: Record<string, string> = {
+  hospital: '病院',
+  shopping: '商業施設',
+  'public-facility': '公共施設',
+}
+
+// APIから取得したタイプに対応する日本語ラベルを取得
+// マッピングにない場合はタイプ名をそのまま返す
+export function getSpotLabel(type: string): string {
+  return SPOT_LABELS[type] || type
+}

--- a/src/lib/spots.ts
+++ b/src/lib/spots.ts
@@ -1,0 +1,62 @@
+export interface Spot {
+  id: string
+  name: string
+  lat: number
+  lng: number
+  type: string
+}
+
+interface SpotsAPIResponse {
+  result: {
+    spots: Array<{
+      id: string
+      lat: number
+      lon: number
+      name: string
+      type: string
+    }>
+    types: string[]
+  }
+  status: string
+}
+
+const API_URL = 'https://prometheus-h24i.onrender.com/area/spots'
+
+export async function fetchSpots(): Promise<{ spots: Spot[]; types: string[] }> {
+  try {
+    const response = await fetch(API_URL, {
+      cache: 'force-cache', // ビルド時にキャッシュ
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch spots: ${response.status}`)
+    }
+
+    const data: SpotsAPIResponse = await response.json()
+
+    if (data.status !== 'OK') {
+      throw new Error(`API returned error status: ${data.status}`)
+    }
+
+    // APIのlon -> lng に変換
+    const spots = data.result.spots.map((spot) => ({
+      id: spot.id,
+      name: spot.name,
+      lat: spot.lat,
+      lng: spot.lon,
+      type: spot.type,
+    }))
+
+    return {
+      spots,
+      types: data.result.types,
+    }
+  } catch (error) {
+    console.error('Error fetching spots:', error)
+    // フォールバック: 空配列
+    return {
+      spots: [],
+      types: [],
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,14 @@ export interface BusStop {
   lng: number
 }
 
+export interface Spot {
+  id: string
+  name: string
+  lat: number
+  lng: number
+  type: string
+}
+
 export interface ReachabilityGeoJSON extends FeatureCollection {
   features: Array<{
     type: 'Feature'
@@ -37,7 +45,8 @@ export interface BusRouteResponse {
 }
 
 // API関連の型定義
-export type FacilityType = 'hospital' | 'shopping'
+// 動的なスポットタイプに対応するためstring型に変更
+export type FacilityType = string
 
 export interface APIRequest {
   'target-spots': FacilityType[]


### PR DESCRIPTION
Closes #10

## 概要
スポット一覧をバックエンドAPIから取得し、種別ごとにマップ上に表示できるようにしました。

## 変更内容
- GET /area/spots APIからスポット一覧を取得（ビルド時）
- 動的な施設タイプシステムに変更（ハードコード削除）
- 検索条件パネルのチェックボックスを動的生成
- 施設タイプ選択とスポット表示を統合（1つのチェックボックスで制御）
- スポットマーカーの表示（種別ごとに異なるアイコン色）
- チェックボックスの状態同期バグを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)