### PR TITLE
fix: サイドバー内スクロールと進む/戻るボタンの固定表示

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,14 @@
 - **ドラッグ&ドロップ**: @dnd-kit (core, sortable, utilities)
 - **パッケージマネージャー**: npm
 
+## 開発環境
+- **開発サーバー**: 常にユーザーが起動済み
+  - `npm run dev` は実行しない（既に起動している）
+  - コード変更は自動でホットリロードされる
+
 ## よく使うコマンド
 ```bash
-npm run dev        # 開発サーバー起動（Turbopack使用）
+npm run dev        # 開発サーバー起動（Turbopack使用）※ユーザーが常時起動済み
 npm run build      # 本番ビルド
 npm run start      # 本番サーバー起動
 npm run lint       # ESLintチェック

--- a/src/components/BusStopSidebar.tsx
+++ b/src/components/BusStopSidebar.tsx
@@ -100,14 +100,14 @@ export default function BusStopSidebar({
   }
   return (
     <div className="bg-white shadow-lg w-80 h-full flex flex-col border-r border-gray-200">
-      <div className="p-4 border-b border-gray-200">
+      <div className="flex-shrink-0 p-4 border-b border-gray-200">
         <h2 className="text-lg font-semibold text-gray-800">停留所選択</h2>
         <p className="text-sm text-gray-600 mt-1">
           コミュニティバスの停留所を選択してください（最低2箇所）
         </p>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4">
+      <div className="flex-1 overflow-y-auto p-4 min-h-0">
         {selectedStops.length === 0 ? (
           <p className="text-sm text-gray-500 text-center mt-8">
             地図上のマーカーをクリックして停留所を選択
@@ -132,7 +132,7 @@ export default function BusStopSidebar({
         )}
       </div>
 
-      <div className="p-4 border-t border-gray-200 space-y-2">
+      <div className="flex-shrink-0 p-4 border-t border-gray-200 space-y-2">
         <button
           onClick={onProceed}
           disabled={!canProceed}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -75,7 +75,7 @@ export default function MapView({ busStops, spots, spotTypes, spotLabels }: MapV
       />
 
       {/* 下部: サイドバーと地図 */}
-      <div className="flex-1 flex">
+      <div className="flex-1 flex overflow-hidden">
         {/* 左サイドバー: 停留所選択 */}
         <BusStopSidebar
           selectedStops={stops.selected}


### PR DESCRIPTION
## 概要
バス停を多数選んだ時に画面全体がスクロールしてしまう問題を修正し、サイドバー内でのみスクロールするように変更しました。

## 変更内容
- MapViewの親コンテナに`overflow-hidden`を追加
- BusStopSidebarのヘッダーとボタン領域に`flex-shrink-0`を追加
- スクロール領域に`min-h-0`を追加してflexbox内で適切にスクロール
- 進むボタンと戻るボタンを常に画面下部に固定表示

## 動作確認
- [x] バス停を多数選択してもサイドバー内でのみスクロール
- [x] 進む/戻るボタンが常に表示される

## その他
- CLAUDE.mdに開発環境の注意事項を追記

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)