### PR TITLE
feat: 地図のズームアウトを富山市内範囲に制限

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -15,6 +15,7 @@ export default function Map({ children, center = [35.6812, 139.7671], zoom = 13 
     <MapContainer
       center={center}
       zoom={zoom}
+      minZoom={11}
       style={{ height: '100%', width: '100%' }}
       className="z-0"
     >


### PR DESCRIPTION
## 概要
富山市全体が収まる程度より外側にはズームアウトできないよう制限を追加しました。

## 変更内容
- `Map.tsx` に `minZoom={11}` オプションを追加
- 富山市全体が見える範囲（zoom level 11）以下にはズームアウト不可

## 動作確認
- ブラウザで地図を表示し、ズームアウト操作が制限されることを確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)