### PR TITLE
feat: 停留所マーカーのポップアップ挙動を改善

### DIFF
--- a/src/components/BusStopMarker.tsx
+++ b/src/components/BusStopMarker.tsx
@@ -9,6 +9,7 @@ interface BusStopMarkerProps {
   isSelected: boolean
   selectionOrder?: number
   onSelect: (stop: BusStop) => void
+  onDeselect?: (stop: BusStop) => void
 }
 
 // カスタムアイコンの作成
@@ -76,23 +77,48 @@ export default function BusStopMarker({
   isSelected,
   selectionOrder,
   onSelect,
+  onDeselect,
 }: BusStopMarkerProps) {
+  const handleClick = () => {
+    // 未選択の場合のみ選択処理を実行
+    if (!isSelected) {
+      onSelect(stop)
+    }
+  }
+
+  const handleDeselect = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (onDeselect) {
+      onDeselect(stop)
+    }
+  }
+
   return (
     <Marker
       position={[stop.lat, stop.lng]}
       icon={createIcon(isSelected, selectionOrder)}
       eventHandlers={{
-        click: () => onSelect(stop),
+        click: handleClick,
       }}
     >
-      <Popup>
-        <div className="text-sm">
-          <p className="font-semibold">{stop.name}</p>
-          {isSelected && selectionOrder !== undefined && (
-            <p className="text-xs text-gray-600 mt-1">選択順: {selectionOrder}</p>
-          )}
-        </div>
-      </Popup>
+      {isSelected && (
+        <Popup>
+          <div className="text-sm">
+            <p className="font-semibold">{stop.name}</p>
+            {selectionOrder !== undefined && (
+              <p className="text-xs text-gray-600 mt-1">選択順: {selectionOrder}</p>
+            )}
+            {onDeselect && (
+              <button
+                onClick={handleDeselect}
+                className="mt-2 w-full px-3 py-1 text-xs font-medium text-white bg-red-500 rounded hover:bg-red-600 transition-colors"
+              >
+                選択を解除
+              </button>
+            )}
+          </div>
+        </Popup>
+      )}
     </Marker>
   )
 }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -140,6 +140,7 @@ export default function MapView({ busStops, spots, spotTypes, spotLabels }: MapV
                   isSelected={isSelected}
                   selectionOrder={isSelected ? selectedIndex + 1 : undefined}
                   onSelect={stops.isEditable ? stops.onSelect : () => {}}
+                  onDeselect={stops.isEditable ? stops.onDeselect : undefined}
                 />
               )
             })}

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -43,15 +43,19 @@ export function useMapState(availableSpotTypes: string[] = []) {
     )
   }, [])
 
-  // --- 停留所選択/解除のハンドラー ---
+  // --- 停留所選択のハンドラー ---
   const handleSelectStop = useCallback((stop: BusStop) => {
     const isSelected = selectedStops.some((s) => s.id === stop.id)
 
-    if (isSelected) {
-      setSelectedStops(selectedStops.filter((s) => s.id !== stop.id))
-    } else {
+    // 未選択の場合のみ選択を追加
+    if (!isSelected) {
       setSelectedStops([...selectedStops, stop])
     }
+  }, [selectedStops])
+
+  // --- 停留所解除のハンドラー ---
+  const handleDeselectStop = useCallback((stop: BusStop) => {
+    setSelectedStops(selectedStops.filter((s) => s.id !== stop.id))
   }, [selectedStops])
 
   // --- 進むボタンのハンドラー ---
@@ -221,6 +225,7 @@ export function useMapState(availableSpotTypes: string[] = []) {
       canProceed: selectedStops.length >= 2 && selectedFacilities.length > 0,
       isEditable,
       onSelect: handleSelectStop,
+      onDeselect: handleDeselectStop,
       onProceed: handleProceed,
       onReset: handleReset,
       onReorder: handleReorderStops,


### PR DESCRIPTION
## 概要
停留所マーカーのクリック時の挙動を改善し、より直感的なユーザー体験を実現しました。

## 変更内容
- 未選択の停留所をクリックした時はポップアップを表示せず、選択状態にする
- 選択済みの停留所をクリックした時のみポップアップを表示
- ポップアップ内に「選択を解除」ボタンを追加
- 停留所の選択と解除のハンドラーを分離してロジックを明確化

## 変更ファイル
- `src/components/BusStopMarker.tsx`: ポップアップ表示制御と解除ボタンの追加
- `src/hooks/useMapState.ts`: 選択/解除ハンドラーの分離
- `src/components/MapView.tsx`: onDeselectプロパティの追加

## 動作確認
- ✅ 未選択の停留所クリック → 選択状態になる（ポップアップなし）
- ✅ 選択済みの停留所クリック → ポップアップ表示
- ✅ 解除ボタンクリック → 選択状態が解除される
- ✅ 型チェック完了

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)