### PR TITLE
feat: 停留所サイドバーの操作性を改善

### DIFF
--- a/src/components/BusStopSidebar.tsx
+++ b/src/components/BusStopSidebar.tsx
@@ -22,13 +22,25 @@ interface BusStopSidebarProps {
   selectedStops: BusStop[]
   onProceed: () => void
   onReset: () => void
+  onDeselect: (stop: BusStop) => void
   canProceed: boolean
+  canReset: boolean
   onReorder: (newStops: BusStop[]) => void
   isEditable: boolean
 }
 
 // ドラッグ可能な停留所アイテムコンポーネント
-function SortableStopItem({ stop, index, isEditable }: { stop: BusStop; index: number; isEditable: boolean }) {
+function SortableStopItem({
+  stop,
+  index,
+  isEditable,
+  onDeselect,
+}: {
+  stop: BusStop
+  index: number
+  isEditable: boolean
+  onDeselect: (stop: BusStop) => void
+}) {
   const {
     attributes,
     listeners,
@@ -58,15 +70,24 @@ function SortableStopItem({ stop, index, isEditable }: { stop: BusStop; index: n
       <span className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">
         {index + 1}
       </span>
-      <span className="text-sm text-gray-800">{stop.name}</span>
+      <span
+        {...attributes}
+        {...listeners}
+        className={`text-sm text-gray-800 flex-1 ${isEditable ? 'cursor-move' : ''}`}
+      >
+        {stop.name}
+      </span>
       {isEditable && (
-        <span
-          {...attributes}
-          {...listeners}
-          className="ml-auto text-gray-400 text-lg cursor-move hover:text-gray-600 px-2"
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onDeselect(stop)
+          }}
+          className="flex-shrink-0 w-6 h-6 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors flex items-center justify-center"
+          aria-label="選択解除"
         >
-          ⋮⋮
-        </span>
+          ✕
+        </button>
       )}
     </li>
   )
@@ -76,7 +97,9 @@ export default function BusStopSidebar({
   selectedStops,
   onProceed,
   onReset,
+  onDeselect,
   canProceed,
+  canReset,
   onReorder,
   isEditable,
 }: BusStopSidebarProps) {
@@ -124,7 +147,13 @@ export default function BusStopSidebar({
             >
               <ol className="space-y-2">
                 {selectedStops.map((stop, index) => (
-                  <SortableStopItem key={stop.id} stop={stop} index={index} isEditable={isEditable} />
+                  <SortableStopItem
+                    key={stop.id}
+                    stop={stop}
+                    index={index}
+                    isEditable={isEditable}
+                    onDeselect={onDeselect}
+                  />
                 ))}
               </ol>
             </SortableContext>
@@ -146,7 +175,12 @@ export default function BusStopSidebar({
         </button>
         <button
           onClick={onReset}
-          className="w-full py-2 px-4 rounded-lg font-medium bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors"
+          disabled={!canReset}
+          className={`w-full py-2 px-4 rounded-lg font-medium transition-colors ${
+            canReset
+              ? 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+          }`}
         >
           戻る
         </button>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -82,7 +82,9 @@ export default function MapView({ busStops, spots, spotTypes, spotLabels }: MapV
           selectedStops={stops.selected}
           onProceed={stops.onProceed}
           onReset={stops.onReset}
+          onDeselect={stops.onDeselect}
           canProceed={stops.canProceed}
+          canReset={stops.canReset}
           onReorder={stops.onReorder}
           isEditable={stops.isEditable}
         />

--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -222,7 +222,8 @@ export function useMapState(availableSpotTypes: string[] = []) {
     // 停留所関連
     stops: {
       selected: selectedStops,
-      canProceed: selectedStops.length >= 2 && selectedFacilities.length > 0,
+      canProceed: selectedStops.length >= 2 && selectedFacilities.length > 0 && isEditable,
+      canReset: !isEditable,
       isEditable,
       onSelect: handleSelectStop,
       onDeselect: handleDeselectStop,


### PR DESCRIPTION
## Summary
- 進む/戻るボタンの活性/非活性制御を実装
- 停留所リストのバツボタンによる選択解除機能を追加
- 停留所名のドラッグで順序変更可能に改善

## 詳細

### ボタン制御 (#21)
- **進むボタン**: 停留所2つ以上選択時のみ有効、押下後は非活性
- **戻るボタン**: 進むボタン押下前は非活性、押下後に有効化

### 停留所リスト操作 (#22)
- 各停留所の右側にバツボタンを配置し、クリックで選択解除
- 停留所名エリアをドラッグして順序変更可能
- 進むボタン押下後は編集ロック（バツボタン非表示、ドラッグ無効）

## Test plan
- [x] 初期状態で戻るボタンが非活性
- [x] 停留所2つ以上選択で進むボタンが有効
- [x] 進むボタン押下後、進むボタンが非活性、戻るボタンが有効
- [x] バツボタンで停留所選択を解除できる
- [x] 停留所名をドラッグして順序変更できる
- [x] 進むボタン押下後は編集不可（バツボタン非表示、ドラッグ無効）
- [x] 戻るボタン押下後、元の編集可能状態に戻る

Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)