### PR TITLE
feat: 停留所マーカーの表示・非表示制御を実装

### DIFF
--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -116,21 +116,28 @@ export default function MapView({ busStops, spots, spotTypes, spotLabels }: MapV
             <BusRoutePolyline stops={stops.selected} />
 
             {/* 停留所マーカー */}
-            {busStops.map((stop) => {
-              const selectedIndex = stops.selected.findIndex((s) => s.id === stop.id)
-              const isSelected = selectedIndex !== -1
+            {busStops
+              .filter((stop) => {
+                // 編集可能時: すべての停留所を表示
+                // 編集不可時: 選択済み停留所のみ表示
+                if (stops.isEditable) return true
+                return stops.selected.some((s) => s.id === stop.id)
+              })
+              .map((stop) => {
+                const selectedIndex = stops.selected.findIndex((s) => s.id === stop.id)
+                const isSelected = selectedIndex !== -1
 
-              return (
-                <BusStopMarker
-                  key={stop.id}
-                  stop={stop}
-                  isSelected={isSelected}
-                  selectionOrder={isSelected ? selectedIndex + 1 : undefined}
-                  onSelect={stops.isEditable ? stops.onSelect : () => {}}
-                  onDeselect={stops.isEditable ? stops.onDeselect : undefined}
-                />
-              )
-            })}
+                return (
+                  <BusStopMarker
+                    key={stop.id}
+                    stop={stop}
+                    isSelected={isSelected}
+                    selectionOrder={isSelected ? selectedIndex + 1 : undefined}
+                    onSelect={stops.isEditable ? stops.onSelect : () => {}}
+                    onDeselect={stops.isEditable ? stops.onDeselect : undefined}
+                  />
+                )
+              })}
 
             {/* スポットマーカー */}
             {spots


### PR DESCRIPTION
## 概要
Issue #36 の対応として、進むボタン押下後は選択されなかった停留所のマーカーを非表示にし、戻るボタンで再度表示する機能を実装しました。

## 変更内容
- [MapView.tsx](src/components/map/MapView.tsx): 停留所マーカーのフィルタリングロジックを追加
  - 編集可能時（`isEditable = true`）: すべての停留所マーカーを表示
  - 編集不可時（`isEditable = false`）: 選択済み停留所のみ表示

## 動作
1. **進むボタン押下後**
   - 選択されなかった停留所マーカーが非表示になる
   - 選択済み停留所マーカーのみ表示される
2. **戻るボタン押下後**
   - すべての停留所マーカーが再表示される

## 関連
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)